### PR TITLE
Implement Admin Mode teacher authentication and protected registration

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,14 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import json
+import uuid
 from pathlib import Path
+from pydantic import BaseModel
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +21,46 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+def load_teacher_credentials() -> dict[str, str]:
+    """Load teacher credentials from a local JSON file."""
+    teachers_path = current_dir / "teachers.json"
+    try:
+        with open(teachers_path, "r", encoding="utf-8") as file:
+            data = json.load(file)
+    except FileNotFoundError as exc:
+        raise RuntimeError("teachers.json file is missing") from exc
+
+    teachers = data.get("teachers", [])
+    return {
+        teacher["username"]: teacher["password"]
+        for teacher in teachers
+        if teacher.get("username") and teacher.get("password")
+    }
+
+
+teacher_credentials = load_teacher_credentials()
+teacher_sessions: dict[str, str] = {}
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def require_teacher(authorization: str | None = Header(default=None)) -> str:
+    """Validate bearer token and return teacher username."""
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Teacher login required")
+
+    token = authorization.split(" ", 1)[1].strip()
+    username = teacher_sessions.get(token)
+
+    if not username:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    return username
 
 # In-memory activity database
 activities = {
@@ -88,8 +131,41 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def teacher_login(credentials: LoginRequest):
+    """Authenticate a teacher and return a session token."""
+    expected_password = teacher_credentials.get(credentials.username)
+    if not expected_password or expected_password != credentials.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = uuid.uuid4().hex
+    teacher_sessions[token] = credentials.username
+
+    return {
+        "token": token,
+        "username": credentials.username
+    }
+
+
+@app.get("/auth/me")
+def auth_me(teacher_username: str = Depends(require_teacher)):
+    """Return the current authenticated teacher username."""
+    return {"username": teacher_username}
+
+
+@app.post("/auth/logout")
+def teacher_logout(teacher_username: str = Depends(require_teacher),
+                   authorization: str | None = Header(default=None)):
+    """Invalidate the current teacher session token."""
+    token = authorization.split(" ", 1)[1].strip()
+    teacher_sessions.pop(token, None)
+    return {"message": f"Logged out {teacher_username}"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str,
+                        email: str,
+                        teacher_username: str = Depends(require_teacher)):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -107,11 +183,16 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Add student
     activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    return {
+        "message": f"Signed up {email} for {activity_name}",
+        "updated_by": teacher_username
+    }
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str,
+                             email: str,
+                             teacher_username: str = Depends(require_teacher)):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -129,4 +210,7 @@ def unregister_from_activity(activity_name: str, email: str):
 
     # Remove student
     activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    return {
+        "message": f"Unregistered {email} from {activity_name}",
+        "updated_by": teacher_username
+    }

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,15 +3,90 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userMenuBtn = document.getElementById("user-menu-btn");
+  const userMenu = document.getElementById("user-menu");
+  const loginActionBtn = document.getElementById("login-action-btn");
+  const teacherStatus = document.getElementById("teacher-status");
+  const loginModal = document.getElementById("login-modal");
+  const closeLoginModal = document.getElementById("close-login-modal");
+  const loginForm = document.getElementById("login-form");
+
+  const AUTH_TOKEN_KEY = "teacherAuthToken";
+  let authToken = localStorage.getItem(AUTH_TOKEN_KEY);
+  let currentTeacher = null;
+
+  function showMessage(text, type = "info") {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function getAuthHeaders() {
+    if (!authToken) return {};
+    return { Authorization: `Bearer ${authToken}` };
+  }
+
+  function closeMenuAndModal() {
+    userMenu.classList.add("hidden");
+    loginModal.classList.add("hidden");
+  }
+
+  function updateAuthUI() {
+    const isLoggedIn = Boolean(authToken && currentTeacher);
+
+    if (isLoggedIn) {
+      loginActionBtn.textContent = "Log Out";
+      teacherStatus.textContent = `Logged in as ${currentTeacher}`;
+      signupForm.querySelector("button[type='submit']").disabled = false;
+    } else {
+      loginActionBtn.textContent = "Teacher Login";
+      teacherStatus.textContent = "Not logged in";
+      signupForm.querySelector("button[type='submit']").disabled = true;
+    }
+  }
+
+  async function verifySession() {
+    if (!authToken) {
+      currentTeacher = null;
+      updateAuthUI();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: getAuthHeaders(),
+      });
+
+      if (!response.ok) {
+        throw new Error("Session invalid");
+      }
+
+      const data = await response.json();
+      currentTeacher = data.username;
+    } catch (_error) {
+      authToken = null;
+      currentTeacher = null;
+      localStorage.removeItem(AUTH_TOKEN_KEY);
+    }
+
+    updateAuthUI();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
       const response = await fetch("/activities");
       const activities = await response.json();
+      const isLoggedIn = Boolean(authToken && currentTeacher);
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +105,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isLoggedIn
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -60,6 +139,10 @@ document.addEventListener("DOMContentLoaded", () => {
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
+
+      if (!isLoggedIn) {
+        showMessage("Teacher login is required to register or unregister students.", "info");
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -80,6 +163,9 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            ...getAuthHeaders(),
+          },
         }
       );
 
@@ -94,6 +180,13 @@ document.addEventListener("DOMContentLoaded", () => {
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
+
+        if (response.status === 401) {
+          authToken = null;
+          currentTeacher = null;
+          localStorage.removeItem(AUTH_TOKEN_KEY);
+          updateAuthUI();
+        }
       }
 
       messageDiv.classList.remove("hidden");
@@ -114,6 +207,11 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!authToken) {
+      showMessage("Please log in as a teacher to register students.", "error");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -124,6 +222,9 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            ...getAuthHeaders(),
+          },
         }
       );
 
@@ -139,6 +240,13 @@ document.addEventListener("DOMContentLoaded", () => {
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
+
+        if (response.status === 401) {
+          authToken = null;
+          currentTeacher = null;
+          localStorage.removeItem(AUTH_TOKEN_KEY);
+          updateAuthUI();
+        }
       }
 
       messageDiv.classList.remove("hidden");
@@ -155,6 +263,84 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  userMenuBtn.addEventListener("click", () => {
+    userMenu.classList.toggle("hidden");
+  });
+
+  loginActionBtn.addEventListener("click", async () => {
+    if (authToken && currentTeacher) {
+      try {
+        await fetch("/auth/logout", {
+          method: "POST",
+          headers: {
+            ...getAuthHeaders(),
+          },
+        });
+      } catch (_error) {
+        // Clear local state even if backend logout fails.
+      }
+
+      authToken = null;
+      currentTeacher = null;
+      localStorage.removeItem(AUTH_TOKEN_KEY);
+      updateAuthUI();
+      closeMenuAndModal();
+      fetchActivities();
+      showMessage("Logged out.", "success");
+      return;
+    }
+
+    loginModal.classList.remove("hidden");
+  });
+
+  closeLoginModal.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  window.addEventListener("click", (event) => {
+    if (event.target === loginModal) {
+      loginModal.classList.add("hidden");
+    }
+
+    if (!userMenu.contains(event.target) && event.target !== userMenuBtn) {
+      userMenu.classList.add("hidden");
+    }
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        showMessage(data.detail || "Login failed", "error");
+        return;
+      }
+
+      authToken = data.token;
+      currentTeacher = data.username;
+      localStorage.setItem(AUTH_TOKEN_KEY, authToken);
+      updateAuthUI();
+      closeMenuAndModal();
+      loginForm.reset();
+      fetchActivities();
+      showMessage(`Welcome, ${currentTeacher}!`, "success");
+    } catch (error) {
+      showMessage("Login failed. Please try again.", "error");
+      console.error("Error during login:", error);
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  verifySession().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,20 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-content">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+
+        <div class="user-controls">
+          <button id="user-menu-btn" class="user-icon-btn" type="button" aria-label="Open teacher menu">👤</button>
+          <div id="user-menu" class="user-menu hidden">
+            <button id="login-action-btn" type="button">Teacher Login</button>
+            <p id="teacher-status" class="teacher-status">Not logged in</p>
+          </div>
+        </div>
+      </div>
     </header>
 
     <main>
@@ -44,6 +56,24 @@
     <footer>
       <p>&copy; 2026 Mergington High School</p>
     </footer>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="teacher-login-title">
+      <div class="modal-content">
+        <button id="close-login-modal" type="button" class="modal-close" aria-label="Close login">&times;</button>
+        <h3 id="teacher-login-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="teacher username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="password" />
+          </div>
+          <button type="submit">Log In</button>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -24,8 +24,53 @@ header {
   border-radius: 5px;
 }
 
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 0 20px;
+}
+
 header h1 {
   margin-bottom: 10px;
+}
+
+.user-controls {
+  position: relative;
+}
+
+.user-icon-btn {
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  padding: 0;
+  font-size: 18px;
+}
+
+.user-menu {
+  position: absolute;
+  right: 0;
+  top: 50px;
+  width: 220px;
+  background-color: white;
+  color: #333;
+  border-radius: 6px;
+  padding: 12px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  z-index: 100;
+}
+
+.user-menu button {
+  width: 100%;
+}
+
+.teacher-status {
+  margin-top: 8px;
+  font-size: 13px;
+  color: #555;
 }
 
 main {
@@ -164,6 +209,50 @@ button:hover {
   background-color: #3949ab;
 }
 
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.modal-content {
+  width: min(420px, 92vw);
+  background: white;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  position: relative;
+}
+
+.modal-content h3 {
+  margin-bottom: 16px;
+  color: #1a237e;
+}
+
+.modal-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  color: #666;
+  font-size: 24px;
+  line-height: 1;
+  padding: 0 6px;
+}
+
+.modal-close:hover {
+  background: #f0f0f0;
+}
+
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -197,4 +286,10 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+@media (max-width: 700px) {
+  .header-content {
+    align-items: center;
+  }
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "mergington123"
+    },
+    {
+      "username": "coach.sam",
+      "password": "soccerStrong!"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements issue #5 by adding an Admin Mode for teachers and restricting registration changes to authenticated staff.

## What changed
- Added teacher credential store in `src/teachers.json`
- Added backend auth endpoints:
  - `POST /auth/login`
  - `GET /auth/me`
  - `POST /auth/logout`
- Added session-token validation via `Authorization: Bearer <token>`
- Protected mutation endpoints so only authenticated teachers can:
  - sign up students
  - unregister students
- Updated frontend with:
  - top-right user icon menu
  - teacher login modal
  - login/logout flow with persisted token
  - register/unregister controls gated by auth state

## Notes
- Students can still view activities and participants without login.
- Teacher credentials are intentionally JSON-backed for now, matching the issue request (no DB yet).

Closes #5